### PR TITLE
Fixed Compilation of Documentation on readthedocs

### DIFF
--- a/conf.py
+++ b/conf.py
@@ -23,6 +23,7 @@ for mod_name in MOCK_MODULES:
 # If extensions (or modules to document with autodoc) are in another directory,
 # add these directories to sys.path here. If the directory is relative to the
 # documentation root, use os.path.abspath to make it absolute, like shown here.
+sys.path.append(os.path.abspath('numpydoc'))
 sys.path.insert(0, os.path.abspath('.'))
 
 # -- General configuration ------------------------------------------------
@@ -35,9 +36,11 @@ sys.path.insert(0, os.path.abspath('.'))
 # ones.
 extensions = [
     'sphinx.ext.autodoc',
+    'sphinx.ext.viewcode',
     'sphinx.ext.doctest',
     'sphinx.ext.coverage',
     'sphinx.ext.mathjax',
+    'numpydoc'
 ]
 
 # Add any paths that contain templates here, relative to this directory.

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,3 @@
 numpydoc==0.5
 numpy==1.9.2
 mock==1.0.1
-scipy

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 numpydoc==0.5
 numpy==1.9.2
 mock==1.0.1
-scipy==0.16.0
+scipy


### PR DESCRIPTION
Made a few minor changes to the way the docs are compiled, and these seem to do the trick to re-enable proper docs compilation on RTD. Deals with Issue #1.