### PR TITLE
Deal with libgfortran build issue

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ before_install:
   - export PATH=/home/travis/miniconda/bin:$PATH
   - conda update --yes conda
 install:
-  - conda create --yes -q -n pyenv python=2.7 numpy=1.9.2 scipy=0.16.0 nose=1.3.7
+  - conda create --yes -q -n pyenv libgfortran python=2.7 numpy=1.9.2 scipy=0.16.0 nose=1.3.7
   - source activate pyenv
   - pip install MDAnalysis==0.12.1
   - pip install coveralls tempdir


### PR DESCRIPTION
Recent travis-ci builds have been failing because:

 `ImportError: libgfortran.so.1: cannot open shared object file: No such file or directory`

This is a simple PR attempting to fix this issue.