### PR TITLE
TST: migration from nose to pytest framework

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,15 +8,11 @@ before_install:
   - export PATH=/home/travis/miniconda/bin:$PATH
   - conda update --yes conda
 install:
-  - conda create --yes -q -n pyenv libgfortran python=2.7 numpy=1.13 scipy=0.19.1 pytest=3.2.1 pytest-cov=2.5.1
+  - conda create --yes -q -n pyenv libgfortran python=2.7 numpy=1.13 scipy=0.19.1 pytest=3.2.1 pytest-cov=2.5.1 pyyaml=3.12
   - source activate pyenv
-  - pip install MDAnalysis==0.16.0
+  - conda config --add channels conda-forge
+  - conda install MDAnalysis=0.16.2
   - pip install coveralls tempdir
-  - wget http://pyyaml.org/download/pyyaml/PyYAML-3.12.tar.gz
-  - tar -zxvf PyYAML-3.12.tar.gz
-  - cd PyYAML-3.12
-  - python setup.py install
-  - cd ../
   - chmod +x ./
 script:
   - pytest --cov=diffusion_analysis --cov-report term-missing test_diffusion_analysis.py

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ before_install:
   - export PATH=/home/travis/miniconda/bin:$PATH
   - conda update --yes conda
 install:
-  - conda create --yes -q -n pyenv libgfortran python=2.7 numpy=1.11 scipy=0.18.0 pytest=3.2.1 pytest-cov=2.5.1
+  - conda create --yes -q -n pyenv libgfortran python=2.7 numpy=1.13 scipy=0.19.1 pytest=3.2.1 pytest-cov=2.5.1
   - source activate pyenv
   - pip install MDAnalysis==0.16.0
   - pip install coveralls tempdir

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ before_install:
   - export PATH=/home/travis/miniconda/bin:$PATH
   - conda update --yes conda
 install:
-  - conda create --yes -q -n pyenv libgfortran python=2.7 numpy=1.11 scipy=0.18.0 nose=1.3.7
+  - conda create --yes -q -n pyenv libgfortran python=2.7 numpy=1.11 scipy=0.18.0 pytest pytest-cov
   - source activate pyenv
   - pip install MDAnalysis==0.16.0
   - pip install coveralls tempdir
@@ -19,6 +19,6 @@ install:
   - cd ../
   - chmod +x ./
 script:
-  - nosetests --with-coverage --cover-package diffusion_analysis test_diffusion_analysis.py
+  - pytest --cov=diffusion_analysis --cov-report term-missing test_diffusion_analysis.py
 after_success:
   - coveralls

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ before_install:
   - export PATH=/home/travis/miniconda/bin:$PATH
   - conda update --yes conda
 install:
-  - conda create --yes -q -n pyenv libgfortran python=2.7 numpy=1.11 scipy=0.18.0 pytest pytest-cov
+  - conda create --yes -q -n pyenv libgfortran python=2.7 numpy=1.11 scipy=0.18.0 pytest=3.2.3 pytest-cov=2.5.1
   - source activate pyenv
   - pip install MDAnalysis==0.16.0
   - pip install coveralls tempdir

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,7 @@ install:
   - conda create --yes -q -n pyenv libgfortran python=2.7 numpy=1.13 scipy=0.19.1 pytest=3.2.1 pytest-cov=2.5.1 pyyaml=3.12
   - source activate pyenv
   - conda config --add channels conda-forge
-  - conda install MDAnalysis=0.16.2
+  - conda install --yes MDAnalysis=0.16.2
   - pip install coveralls tempdir
   - chmod +x ./
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ before_install:
   - export PATH=/home/travis/miniconda/bin:$PATH
   - conda update --yes conda
 install:
-  - conda create --yes -q -n pyenv libgfortran python=2.7 numpy=1.11 scipy=0.18.0 pytest=3.2.3 pytest-cov=2.5.1
+  - conda create --yes -q -n pyenv libgfortran python=2.7 numpy=1.11 scipy=0.18.0 pytest=3.2.1 pytest-cov=2.5.1
   - source activate pyenv
   - pip install MDAnalysis==0.16.0
   - pip install coveralls tempdir


### PR DESCRIPTION
This WIP PR attempts to migrate the library CI testing from usage of `nose` to usage of the actively maintained `pytest`. I may also try to squeeze in a few more improvements / updates to the CI code here.

Related to #11.