### PR TITLE
TST: use stable version of MDAnalysis in CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,8 +15,7 @@ install:
   - conda create -q -n pyenv libgfortran python=$TRAVIS_PYTHON_VERSION numpy=1.13 scipy=0.19.1 pytest=3.2.1 pytest-cov=2.5.1 pyyaml=3.12
   - source activate pyenv
   - conda config --add channels conda-forge
-  # need the dev branch of MDAnalysis to get Python 3 support for now
-  - conda install -c kain88-de mdanalysis=0.17.0dev
+  - conda install -c conda-forge mdanalysis
   - pip install coveralls tempdir
   - chmod +x ./
 script:


### PR DESCRIPTION
Shouldn't need to use the old dev version from Max's channel any more